### PR TITLE
Taimen also requires make brillo_update_payload

### DIFF
--- a/build-android
+++ b/build-android
@@ -70,7 +70,7 @@ popd
 echo ===Making target files package=== >&2
 make target-files-package -j"$NUM_CORES"
 
-if [ "$PRODUCT_NAME" == "sailfish" -o "$PRODUCT_NAME" == "marlin" ] ; then
+if [ "$PRODUCT_NAME" == "sailfish" -o "$PRODUCT_NAME" == "marlin" -o "$PRODUCT_NAME" == "taimen" ] ; then
   echo ===Making Brillo update payload=== >&2
   make -j20 brillo_update_payload
 fi


### PR DESCRIPTION
Without this the build for Taimen will result in
```
+ build/tools/releasetools/ota_from_target_files --block -k keys/taimen/releasekey out/release-taimen-2018.03.28.19/taimen-target_files-2018.03.28.19.zip out/release-taimen-2018.03.28.19/taimen-ota_update-2018.03.28.19.zip
Traceback (most recent call last):
  File "build/tools/releasetools/ota_from_target_files", line 1547, in <module>
    main(sys.argv[1:])
  File "build/tools/releasetools/ota_from_target_files", line 1432, in main
    source_file=OPTIONS.incremental_source)
  File "build/tools/releasetools/ota_from_target_files", line 1097, in WriteABOTAPackageWithBrilloScript
    p1 = common.Run(cmd, stdout=log_file, stderr=subprocess.STDOUT)
  File "/tmp/android-build-root/src/build/make/tools/releasetools/common.py", line 121, in Run
    return subprocess.Popen(args, **kwargs)
  File "/usr/lib64/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1025, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
+ exit 1
```